### PR TITLE
Fix 'mediaItems.create' REST-URI-FRAGMENT

### DIFF
--- a/trunk/Social-API-Server.xml
+++ b/trunk/Social-API-Server.xml
@@ -1371,7 +1371,7 @@ http://api.example.org/rpc?method=appdata.update&amp;id=setMyData&amp;appId=app1
       <artwork type="abnf"
          xml:space="preserve">
 <eref target="Core-API-Server.xml#REST-HTTP-Method">REST-HTTP-Method</eref>       = "POST"
-<eref target="Core-API-Server.xml#REST-URI-Fragment">REST-URI-Fragment</eref>      = "/mediaItem/" <eref target="Core-Data.xml#User-Id">User-Id</eref> "/@self/" Album-Id
+<eref target="Core-API-Server.xml#REST-URI-Fragment">REST-URI-Fragment</eref>      = "/mediaItems/" <eref target="Core-Data.xml#User-Id">User-Id</eref> "/@self/" Album-Id
 <eref target="Core-API-Server.xml#REST-Query-Parameters">REST-Query-Parameters</eref>  = null 
 <eref target="Core-API-Server.xml#REST-Request-Payload">REST-Request-Payload</eref>   = <eref target="Social-Data.xml#MediaItem">MediaItem</eref>
 


### PR DESCRIPTION
There is a simple typo here: all other media items requests are under /mediaItems/, and based
on the RPC-Method rule this one should be too.
